### PR TITLE
peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npm run clean; tsc -d -t es2015 && mv ./index.js ./index.es2015.js && tsc -t es5",
     "clean": "rm ./*.d.ts; rm ./*.map; exit 0",
     "pretest": "npm run build",
-    "prepublish": "npm test",
+    "prepare": "npm test",
     "test": "karma start --single-run",
     "tdd": "npm-run-all -pr watch:*",
     "watch:ts": "tsc -w",
@@ -29,12 +29,23 @@
   "peerDependencies": {
     "prop-types": ">=15",
     "react": ">=15",
-    "react-dom": ">=15"
+    "react-dom": ">=15",
+    "@types/angular-mocks": ">=1.5",
+    "@types/angular": ">=1.5",
+    "@types/jasmine": "^2.5.53",
+    "@types/jquery": "^3.2.10",
+    "@types/lodash.frompairs": "^4.0.3",
+    "@types/react-dom": ">=15",
+    "@types/react": ">=15"
   },
   "devDependencies": {
+    "@types/angular": ">=1.5",
     "@types/angular-mocks": ">=1.5",
     "@types/jasmine": "^2.5.53",
     "@types/jquery": "^3.2.10",
+    "@types/lodash.frompairs": "^4.0.3",
+    "@types/react": ">=15",
+    "@types/react-dom": ">=15",
     "angular-mocks": ">=1.5",
     "jasmine": "^2.8.0",
     "karma": "^1.7.0",
@@ -54,10 +65,6 @@
     "watchify": "^3.9.0"
   },
   "dependencies": {
-    "@types/angular": ">=1.5",
-    "@types/lodash.frompairs": "^4.0.3",
-    "@types/react": "^16.0.0",
-    "@types/react-dom": "^15.5.1",
     "angular": ">=1.5.11",
     "lodash.frompairs": "^4.0.1",
     "ngcomponent": "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,15 +36,20 @@
   version "4.14.76"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.76.tgz#87874f766774d54e89589697340be9496fb8bf70"
 
-"@types/react-dom@^15.5.1":
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-15.5.4.tgz#3f75ba86a2ce9a7d1d9e7d1ee3f186f3a9652d8f"
+"@types/node@*":
+  version "8.0.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.34.tgz#55f801fa2ddb2a40dd6dfc15ecfe1dde9c129fe9"
+
+"@types/react-dom@>=15":
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.1.tgz#de159d00dd70050000f462e8bcff0c08ef803dee"
   dependencies:
+    "@types/node" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.0.0":
-  version "16.0.7"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.7.tgz#f85b6c33c988a1631e2f32fedae71ec6d9718a0d"
+"@types/react@*", "@types/react@>=15":
+  version "16.0.10"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.10.tgz#a24b630f5f1f170866a148a147d4fc8636ea88e0"
 
 JSONStream@^1.0.3:
   version "1.3.1"


### PR DESCRIPTION
@jacobleesinger I could be wrong on this, but I'm seeing weird dumb errors from TS because it's trying to join `/node_modules/@types/react-dom/node_modules/@types/react` with `/node_modules/@types/react2angular/node_modules/@types/react` (I removed the top level `@types/react` b/c I was just gonna rely on the `react-dom` ones, but seeing errors when there's another set of definitions here.)

I'm proposing that anything in devDeps that is typescript related gets copied to `peerDependencies` b/c we can enforce that correctly. (Haven't messed much with peerDeps before, so could be doing something janky here.)

Tried testing with `npm link` but it is unfriendly and annoying.